### PR TITLE
User Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,7 @@ tmp/
 temp/
 
 # End of https://www.gitignore.io/api/node,jetbrains
+
+
+# Devmod config file
+config.ts

--- a/config.template.ts
+++ b/config.template.ts
@@ -1,0 +1,18 @@
+import { UserConfigInterface } from "./src/types/interfaces/UserConfigInterface";
+
+export default {
+  token: "",
+  guildID: "",
+  channelIDs: {
+    warn: "",
+    ban: "",
+    reports: "",
+    assignRoles: "",
+    info: "",
+    errors: ""
+  },
+  roleIDs: {
+    muted: "",
+    verified: ""
+  }
+} as UserConfigInterface;

--- a/src/Devmod.ts
+++ b/src/Devmod.ts
@@ -21,6 +21,7 @@ import { SubmodulesInterface } from './types/interfaces/SubmodulesInterface'
 import { DevmodError } from './types/errors/DevmodError'
 import { CommandInterface } from './types/interfaces/CommandInterface'
 import { commands as defaultCommands } from './commands'
+import userConfig from '../config'
 
 export class Devmod {
     // The client, config, and processes are all accessible from anywhere within the class
@@ -31,9 +32,15 @@ export class Devmod {
     public readonly sub: Partial<SubmodulesInterface> = {}
 
     // The bot will be connected once the constructor is called
-    constructor (commands: CommandInterface[], processes: ProcessInterface[], config: UserConfigInterface) {
-        this.config = mergeConfigs(config)
-        this.config.commands = this.config.populateCommands ? [...defaultCommands, ...commands] : commands
+    constructor(
+        commands: CommandInterface[],
+        processes: ProcessInterface[],
+        config: UserConfigInterface
+    ) {
+        this.config = mergeConfigs(config, userConfig)
+        this.config.commands = this.config.populateCommands
+            ? [...defaultCommands, ...commands]
+            : commands
 
         this.client = new Client()
 
@@ -43,9 +50,15 @@ export class Devmod {
             log('Init', `Logged in as ${this.client.user.tag}.`)
 
             // Initialize all the processes.
-            for (const process of this.config.loadCommandListener ? [commandListener, ...processes] : processes) {
+            for (const process of this.config.loadCommandListener
+                ? [commandListener, ...processes]
+                : processes) {
                 log('Init', `Initialized ${process.name}!`)
-                process.init(this.client, this.config, this.sub as SubmodulesInterface)
+                process.init(
+                    this.client,
+                    this.config,
+                    this.sub as SubmodulesInterface
+                )
             }
         })
 
@@ -58,14 +71,19 @@ export class Devmod {
         this.sub.utils = new Utils(this.client, this.config)
 
         // Direct errors to be handled by the error handling function (uncaught exceptions left untouched for now)
-        process.on('unhandledRejection', (e: DevmodError) => handleErrors(e, this.config, this.sub as SubmodulesInterface))
+        process.on('unhandledRejection', (e: DevmodError) =>
+            handleErrors(e, this.config, this.sub as SubmodulesInterface)
+        )
         // process.on('uncaughtException', handleErrors)
     }
 
     // Hydrates the guild, channels, and roles properties in the config
-    private hydrateConfig (): void {
+    private hydrateConfig(): void {
         this.config.guild = hydrateGuild(this.client, this.config.guildID)
-        this.config.channels = hydrateChannels(this.config.guild, this.config.channelIDs)
+        this.config.channels = hydrateChannels(
+            this.config.guild,
+            this.config.channelIDs
+        )
         this.config.roles = hydrateRoles(this.config.guild, this.config.roleIDs)
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,14 @@
 
 import { Devmod } from './Devmod'
 import { config } from 'dotenv'
-import { Client, DMChannel, GuildMember, Message, PartialMessage, TextChannel } from 'discord.js'
+import {
+    Client,
+    DMChannel,
+    GuildMember,
+    Message,
+    PartialMessage,
+    TextChannel
+} from 'discord.js'
 import { ConfigInterface } from './types/interfaces/ConfigInterface'
 import { log } from './utils/log'
 import { CommandInterface } from './types/interfaces/CommandInterface'
@@ -16,18 +23,18 @@ config()
 const main = () => {
     const config = {
         token: process.env.BOT_TOKEN || '',
-        guildID: '431641323578327050',
+        guildID: '',
         channelIDs: {
-            warn: '432010493213802517',
-            ban: '432010505000058881',
-            reports: '432998514193334283',
-            assignRoles: '593131994096074764',
-            info: '598697397039792128',
-            errors: '618740166630309909'
+            warn: '',
+            ban: '',
+            reports: '',
+            assignRoles: '',
+            info: '',
+            errors: ''
         },
         roleIDs: {
-            muted: '593132538285916171',
-            verified: '598708805487820811'
+            muted: '',
+            verified: ''
         }
     }
     const commands: CommandInterface[] = [
@@ -37,9 +44,20 @@ const main = () => {
             category: 'utils',
             description: 'Test command',
             permissions: ['ADMINISTRATOR'],
-            exec (message: Message | PartialMessage, args: string[], channel: TextChannel | DMChannel, member: GuildMember, client: Client, config: ConfigInterface, sub: SubmodulesInterface) {
+            exec(
+                message: Message | PartialMessage,
+                args: string[],
+                channel: TextChannel | DMChannel,
+                member: GuildMember,
+                client: Client,
+                config: ConfigInterface,
+                sub: SubmodulesInterface
+            ) {
                 log('Test', `Test Message: ${args.join(' ') || 'test!'}`)
-                return channel.send(`Test Message: ${args.join(' ') || 'test!'}`).then().catch()
+                return channel
+                    .send(`Test Message: ${args.join(' ') || 'test!'}`)
+                    .then()
+                    .catch()
             }
         }
     ]

--- a/src/utils/config/mergeConfig.ts
+++ b/src/utils/config/mergeConfig.ts
@@ -7,13 +7,20 @@ import { ConfigInterface } from '../../types/interfaces/ConfigInterface'
 import { UserConfigInterface } from '../../types/interfaces/UserConfigInterface'
 import { join } from 'path'
 
-export const mergeConfigs = (config: UserConfigInterface): ConfigInterface => {
+export const mergeConfigs = (
+    ...configs: UserConfigInterface[]
+): ConfigInterface => {
+    const config = Object.assign({}, ...configs)
+
     return {
         token: config.token, // Discord API token for the bot.
         guildID: config.guildID, // Discord ID of the server your bot is running on.
         prefix: config.prefix || '.', // Prefix to identify commands.
         loadCommandListener: config.loadCommandListener || true, // Whether or not to load the command listener.
-        populateCommands: Object.prototype.hasOwnProperty.call(config, 'populateCommands')
+        populateCommands: Object.prototype.hasOwnProperty.call(
+            config,
+            'populateCommands'
+        )
             ? config.populateCommands
             : true, // Whether or not to load in all the default commands
         commands: [], // Empty array of commands.

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -29,5 +29,6 @@ export const logErrorToChannel = (
     sub: SubmodulesInterface
 ): Promise<Message> => {
     logError(error)
-    return config.channels.errors.send(sub.create.errorMessage(error))
+    if (config.channels)
+        return config.channels.errors.send(sub.create.errorMessage(error))
 }


### PR DESCRIPTION
Fixes #4

- Finished setting up the `mergeConfigs` function and added a template config. 
- Set all of the default configuration values to blank.
- Fixed a bug where the bot would throw infinitely if `config.channels.errors` wasn't set yet (before the `bot.ready` event)

side note: Prettier config may be incomplete or invalid, pre-commit script changed a bunch of files.